### PR TITLE
Update goreleaser "main" package build configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ builds:
   - # First Build
     env:
     - CGO_ENABLED=0
-    main: main.go
+    main: .
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     # Set the binary output location to bin/ so archive will comply with Sensu Go Asset structure
     binary: bin/{{ .ProjectName }}


### PR DESCRIPTION
I think this is the first golang project I've encountered with a multi-file `main` package. TIL! 

Anyway, while the project builds fine with `go get && go build`, a `goreleser --rm-dist --snapshot` was failing to build with errors indicating that certain functions were undefined.

```
$ goreleaser --rm-dist --snapshot

   • releasing using goreleaser 0.130.2...
   • loading config file       file=.goreleaser.yml
   • running before hooks
   • loading environment variables
      • pipe skipped              error=publishing is disabled
   • getting and validating git state
      • ignoring errors because this is a snapshot error=git doesn't contain any tags. Either add a tag or use --snapshot
      • releasing v0.0.0, commit 9830bc09847b791eb742929ab9e8f97fcf8196bf
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag
   • setting defaults
      • snapshoting
      • github/gitlab/gitea releases
      • project name
      • building binaries
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images
      • artifactory
      • blobs
      • homebrew tap formula
      • scoop manifests
   • snapshoting
   • checking ./dist
      • --rm-dist is set, cleaning it up
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • pipe skipped              error=not available for snapshots
   • building binaries
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_windows_amd64/bin/system-check.exe
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_linux_arm_7/bin/system-check
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_linux_arm_6/bin/system-check
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_linux_arm_5/bin/system-check
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_darwin_amd64/bin/system-check
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_linux_386/bin/system-check
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_linux_amd64/bin/system-check
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_windows_386/bin/system-check.exe
      • building                  binary=/home/calebhailey/projects/sensu/system-check/dist/system-check_linux_arm64/bin/system-check
   ⨯ release failed after 0.89s error=failed to build for windows_amd64: # command-line-arguments
./main.go:84:15: undefined: getCPUMetrics
./main.go:89:15: undefined: getMemMetrics
./main.go:94:15: undefined: getLoadMetrics
./main.go:99:15: undefined: getHostMetrics
``` 

Goreleaser offers support for configuring the `main` package build instruction via the `builds.[].main` field: "Path to main.go file or main package." which has a default value of `.`, which fixes goreleaser builds for this project. 

This might be the smallest change I've ever opened a PR for! :tada: