### PR TITLE
Minor output formatting improvements

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -63,6 +63,7 @@ func getCPUMetrics(timestamp int64, interval int) ([]PromMetric, error) {
 			Value:       cores,
 			Type:        "gauge",
 			HelpComment: "Number of cpu cores on the system",
+			IncludeComments: true,
 		},
 	}
 	for i := range cpuStartTimes {

--- a/main.go
+++ b/main.go
@@ -118,8 +118,8 @@ func executeCheck(event *v2.Event) (int, error) {
 		return sensu.CheckStateCritical, err
 	}
 	for i := range metrics {
-		fmt.Println("")
 		fmt.Println(metrics[i].Output())
 	}
+	fmt.Println("")
 	return sensu.CheckStateOK, nil
 }


### PR DESCRIPTION
Changes: 

- Add missing HELP/TYPE comments for `system_cpu_cores` 
- Remove superfluous line breaks between measurements
- Add one newline at EOF

Before: 

```
system_cpu_cores{} 8 1631215534815

# HELP system_cpu_idle [GAUGE] Percent of time all cpus were idle
# TYPE system_cpu_idle GAUGE
system_cpu_idle{cpu="cpu0"} 58.46153846153847 1631215534815

system_cpu_idle{cpu="cpu1"} 50.259067357512954 1631215534815

system_cpu_idle{cpu="cpu2"} 58.549222797927456 1631215534815

system_cpu_idle{cpu="cpu3"} 69.43005181347151 1631215534815

system_cpu_idle{cpu="cpu4"} 72.53886010362694 1631215534815

system_cpu_idle{cpu="cpu5"} 72.02072538860104 1631215534815

system_cpu_idle{cpu="cpu6"} 81.34715025906736 1631215534815

system_cpu_idle{cpu="cpu7"} 80.31088082901555 1631215534815

system_cpu_idle{cpu="cpu-total"} 67.94041450777202 1631215534815

# HELP system_cpu_used [GAUGE] Percent of time all cpus were used
# TYPE system_cpu_used GAUGE
system_cpu_used{cpu="cpu0"} 41.53846153846153 1631215534815

system_cpu_used{cpu="cpu1"} 49.740932642487046 1631215534815

system_cpu_used{cpu="cpu2"} 41.450777202072544 1631215534815

system_cpu_used{cpu="cpu3"} 30.569948186528492 1631215534815

system_cpu_used{cpu="cpu4"} 27.461139896373055 1631215534815

system_cpu_used{cpu="cpu5"} 27.979274611398964 1631215534815

system_cpu_used{cpu="cpu6"} 18.652849740932638 1631215534815

system_cpu_used{cpu="cpu7"} 19.689119170984455 1631215534815

system_cpu_used{cpu="cpu-total"} 32.05958549222798 1631215534815

# HELP system_cpu_user [GAUGE] Percent of time total cpu was used by normal processes in user mode
# TYPE system_cpu_user GAUGE
system_cpu_user{cpu="cpu0"} 20 1631215534815

system_cpu_user{cpu="cpu1"} 15.544041450777202 1631215534815

system_cpu_user{cpu="cpu2"} 20.72538860103627 1631215534815

system_cpu_user{cpu="cpu3"} 16.06217616580311 1631215534815

system_cpu_user{cpu="cpu4"} 12.435233160621761 1631215534815

system_cpu_user{cpu="cpu5"} 12.953367875647666 1631215534815

system_cpu_user{cpu="cpu6"} 8.808290155440414 1631215534815

system_cpu_user{cpu="cpu7"} 9.844559585492227 1631215534815

system_cpu_user{cpu="cpu-total"} 14.572538860103625 1631215534815

# HELP system_cpu_system [GAUGE] Percent of time all cpus used by processes executed in kernel mode
# TYPE system_cpu_system GAUGE
system_cpu_system{cpu="cpu0"} 20.51282051282051 1631215534815

system_cpu_system{cpu="cpu1"} 34.196891191709845 1631215534815

system_cpu_system{cpu="cpu2"} 20.72538860103627 1631215534815

system_cpu_system{cpu="cpu3"} 14.507772020725387 1631215534815

system_cpu_system{cpu="cpu4"} 15.025906735751295 1631215534815

system_cpu_system{cpu="cpu5"} 15.025906735751295 1631215534815

system_cpu_system{cpu="cpu6"} 9.844559585492227 1631215534815

system_cpu_system{cpu="cpu7"} 9.844559585492227 1631215534815

system_cpu_system{cpu="cpu-total"} 17.487046632124354 1631215534815

# HELP system_cpu_nice [GAUGE] Percent of time all cpus used by niced processes in user mode
# TYPE system_cpu_nice GAUGE
system_cpu_nice{cpu="cpu0"} 0 1631215534815

system_cpu_nice{cpu="cpu1"} 0 1631215534815

system_cpu_nice{cpu="cpu2"} 0 1631215534815

system_cpu_nice{cpu="cpu3"} 0 1631215534815

system_cpu_nice{cpu="cpu4"} 0 1631215534815

system_cpu_nice{cpu="cpu5"} 0 1631215534815

system_cpu_nice{cpu="cpu6"} 0 1631215534815

system_cpu_nice{cpu="cpu7"} 0 1631215534815

system_cpu_nice{cpu="cpu-total"} 0 1631215534815

# HELP system_cpu_iowait [GAUGE] Percent of time all cpus waiting for I/O to complete
# TYPE system_cpu_iowait GAUGE
system_cpu_iowait{cpu="cpu0"} 0 1631215534815

system_cpu_iowait{cpu="cpu1"} 0 1631215534815

system_cpu_iowait{cpu="cpu2"} 0 1631215534815

system_cpu_iowait{cpu="cpu3"} 0 1631215534815

system_cpu_iowait{cpu="cpu4"} 0 1631215534815

system_cpu_iowait{cpu="cpu5"} 0 1631215534815

system_cpu_iowait{cpu="cpu6"} 0 1631215534815

system_cpu_iowait{cpu="cpu7"} 0 1631215534815

system_cpu_iowait{cpu="cpu-total"} 0 1631215534815

# HELP system_cpu_irq [GAUGE] Percent of time all cpus servicing interrupts
# TYPE system_cpu_irq GAUGE
system_cpu_irq{cpu="cpu0"} 1.0256410256410255 1631215534815

system_cpu_irq{cpu="cpu1"} 0 1631215534815

system_cpu_irq{cpu="cpu2"} 0 1631215534815

system_cpu_irq{cpu="cpu3"} 0 1631215534815

system_cpu_irq{cpu="cpu4"} 0 1631215534815

system_cpu_irq{cpu="cpu5"} 0 1631215534815

system_cpu_irq{cpu="cpu6"} 0 1631215534815

system_cpu_irq{cpu="cpu7"} 0 1631215534815

system_cpu_irq{cpu="cpu-total"} 0 1631215534815

# HELP system_cpu_sortirq [GAUGE] Percent of time all cpus servicing software interrupts
# TYPE system_cpu_sortirq GAUGE
system_cpu_sortirq{cpu="cpu0"} 0 1631215534815

system_cpu_sortirq{cpu="cpu1"} 0 1631215534815

system_cpu_sortirq{cpu="cpu2"} 0 1631215534815

system_cpu_sortirq{cpu="cpu3"} 0 1631215534815

system_cpu_sortirq{cpu="cpu4"} 0 1631215534815

system_cpu_sortirq{cpu="cpu5"} 0 1631215534815

system_cpu_sortirq{cpu="cpu6"} 0 1631215534815

system_cpu_sortirq{cpu="cpu7"} 0 1631215534815

system_cpu_sortirq{cpu="cpu-total"} 0 1631215534815

# HELP system_cpu_stolen [GAUGE] Percent of time all cpus serviced virtual hosts operating systems
# TYPE system_cpu_stolen GAUGE
system_cpu_stolen{cpu="cpu0"} 0 1631215534815

system_cpu_stolen{cpu="cpu1"} 0 1631215534815

system_cpu_stolen{cpu="cpu2"} 0 1631215534815

system_cpu_stolen{cpu="cpu3"} 0 1631215534815

system_cpu_stolen{cpu="cpu4"} 0 1631215534815

system_cpu_stolen{cpu="cpu5"} 0 1631215534815

system_cpu_stolen{cpu="cpu6"} 0 1631215534815

system_cpu_stolen{cpu="cpu7"} 0 1631215534815

system_cpu_stolen{cpu="cpu-total"} 0 1631215534815

# HELP system_cpu_guest [GAUGE] Percent of time all cpus serviced guest operating system
# TYPE system_cpu_guest GAUGE
system_cpu_guest{cpu="cpu0"} 0 1631215534815

system_cpu_guest{cpu="cpu1"} 0 1631215534815

system_cpu_guest{cpu="cpu2"} 0 1631215534815

system_cpu_guest{cpu="cpu3"} 0 1631215534815

system_cpu_guest{cpu="cpu4"} 0 1631215534815

system_cpu_guest{cpu="cpu5"} 0 1631215534815

system_cpu_guest{cpu="cpu6"} 0 1631215534815

system_cpu_guest{cpu="cpu7"} 0 1631215534815

system_cpu_guest{cpu="cpu-total"} 0 1631215534815

# HELP system_cpu_guest_nice [GAUGE] Percent of time all cpus serviced niced guest operating system
# TYPE system_cpu_guest_nice GAUGE
system_cpu_guest_nice{cpu="cpu0"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu1"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu2"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu3"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu4"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu5"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu6"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu7"} 0 1631215534815

system_cpu_guest_nice{cpu="cpu-total"} 0 1631215534815

# HELP system_mem_used [GAUGE] Percent of memory used
# TYPE system_mem_used GAUGE
system_mem_used{} 48.987483619559136 1631215534815

# HELP system_mem_used_bytes [GAUGE] Used memory in bytes
# TYPE system_mem_used_bytes GAUGE
system_mem_used_bytes{} 8.265371648e+09 1631215534815

# HELP system_mem_total_bytes [GAUGE] Total memory in bytes
# TYPE system_mem_total_bytes GAUGE
system_mem_total_bytes{} 1.6872415232e+10 1631215534815

# HELP system_swap_used [GAUGE] Percent of swap used
# TYPE system_swap_used GAUGE
system_swap_used{} 57.7193339117312 1631215534815

# HELP system_swap_used_bytes [GAUGE] Used swap in bytes
# TYPE system_swap_used_bytes GAUGE
system_swap_used_bytes{} 8.265371648e+09 1631215534815

# HELP system_swap_total_bytes [GAUGE] Total swap in bytes
# TYPE system_swap_total_bytes GAUGE
system_swap_total_bytes{} 1.9422552064e+10 1631215534815

# HELP system_load_load1 [GAUGE] System load averaged over 1 minute, high load value dependant on number of cpus in system
# TYPE system_load_load1 GAUGE
system_load_load1{} 0 1631215534815

# HELP system_load_load5 [GAUGE] System load averaged over 5 minute, high load value dependent on number of cpus in system
# TYPE system_load_load5 GAUGE
system_load_load5{} 0 1631215534815

# HELP system_load_load15 [GAUGE] System load averaged over 15 minute, high load value dependent on number of cpus in system
# TYPE system_load_load15 GAUGE
system_load_load15{} 0 1631215534815

# HELP system_load_load1_per_cpu [GAUGE] System load averaged over 1 minute normalized by cpu count, values > 1 means system may be overloaded
# TYPE system_load_load1_per_cpu GAUGE
system_load_load1_per_cpu{} 0 1631215534815

# HELP system_load_load5_per_cpu [GAUGE] System load averaged over 5 minute normalized by cpu count, values > 1 means system may be overloaded
# TYPE system_load_load5_per_cpu GAUGE
system_load_load5_per_cpu{} 0 1631215534815

# HELP system_load_load15_per_cpu [GAUGE] System load averaged over 15 minute normalized by cpu count, values > 1 means system may be overloaded
# TYPE system_load_load15_per_cpu GAUGE
system_load_load15_per_cpu{} 0 1631215534815

# HELP system_host_uptime [COUNTER] Host uptime in seconds
# TYPE system_host_uptime COUNTER
system_host_uptime{} 1.172814e+06 1631215534815

# HELP system_host_processes [GAUGE] Number of host processes
# TYPE system_host_processes GAUGE
system_host_processes{} 253 1631215534815
```

After: 

```
# HELP system_cpu_cores [GAUGE] Number of cpu cores on the system
# TYPE system_cpu_cores GAUGE
system_cpu_cores{} 8 1631218450712
# HELP system_cpu_idle [GAUGE] Percent of time all cpus were idle
# TYPE system_cpu_idle GAUGE
system_cpu_idle{cpu="cpu0"} 93.6666666685293 1631218450712
system_cpu_idle{cpu="cpu1"} 91.14754098313101 1631218450712
system_cpu_idle{cpu="cpu2"} 93.64548494438971 1631218450712
system_cpu_idle{cpu="cpu3"} 90.60402684464128 1631218450712
system_cpu_idle{cpu="cpu4"} 91.08910891035852 1631218450712
system_cpu_idle{cpu="cpu5"} 93.64548494438971 1631218450712
system_cpu_idle{cpu="cpu6"} 93.68770763582503 1631218450712
system_cpu_idle{cpu="cpu7"} 84.89932886052863 1631218450712
system_cpu_idle{cpu="cpu-total"} 91.47963424480207 1631218450712
# HELP system_cpu_used [GAUGE] Percent of time all cpus were used
# TYPE system_cpu_used GAUGE
system_cpu_used{cpu="cpu0"} 6.333333331470698 1631218450712
system_cpu_used{cpu="cpu1"} 8.852459016868991 1631218450712
system_cpu_used{cpu="cpu2"} 6.3545150556102925 1631218450712
system_cpu_used{cpu="cpu3"} 9.395973155358718 1631218450712
system_cpu_used{cpu="cpu4"} 8.910891089641481 1631218450712
system_cpu_used{cpu="cpu5"} 6.3545150556102925 1631218450712
system_cpu_used{cpu="cpu6"} 6.312292364174965 1631218450712
system_cpu_used{cpu="cpu7"} 15.100671139471373 1631218450712
system_cpu_used{cpu="cpu-total"} 8.520365755197929 1631218450712
# HELP system_cpu_user [GAUGE] Percent of time total cpu was used by normal processes in user mode
# TYPE system_cpu_user GAUGE
system_cpu_user{cpu="cpu0"} 3.333333333042295 1631218450712
system_cpu_user{cpu="cpu1"} 4.262295081577702 1631218450712
system_cpu_user{cpu="cpu2"} 3.01003344496092 1631218450712
system_cpu_user{cpu="cpu3"} 7.0469798660307195 1631218450712
system_cpu_user{cpu="cpu4"} 6.27062706224503 1631218450712
system_cpu_user{cpu="cpu5"} 4.013377926452331 1631218450712
system_cpu_user{cpu="cpu6"} 3.6544850495592347 1631218450712
system_cpu_user{cpu="cpu7"} 13.422818791834882 1631218450712
system_cpu_user{cpu="cpu-total"} 5.6109725688440095 1631218450712
# HELP system_cpu_system [GAUGE] Percent of time all cpus used by processes executed in kernel mode
# TYPE system_cpu_system GAUGE
system_cpu_system{cpu="cpu0"} 1.6666666666424135 1631218450712
system_cpu_system{cpu="cpu1"} 1.967213114647726 1631218450712
system_cpu_system{cpu="cpu2"} 2.006688963104494 1631218450712
system_cpu_system{cpu="cpu3"} 2.01342281884848 1631218450712
system_cpu_system{cpu="cpu4"} 1.9801980198269442 1631218450712
system_cpu_system{cpu="cpu5"} 2.006688963104494 1631218450712
system_cpu_system{cpu="cpu6"} 2.3255813951520836 1631218450712
system_cpu_system{cpu="cpu7"} 1.6778523489793602 1631218450712
system_cpu_system{cpu="cpu-total"} 2.036575228512324 1631218450712
# HELP system_cpu_nice [GAUGE] Percent of time all cpus used by niced processes in user mode
# TYPE system_cpu_nice GAUGE
system_cpu_nice{cpu="cpu0"} 0 1631218450712
system_cpu_nice{cpu="cpu1"} 0 1631218450712
system_cpu_nice{cpu="cpu2"} 0 1631218450712
system_cpu_nice{cpu="cpu3"} 0 1631218450712
system_cpu_nice{cpu="cpu4"} 0 1631218450712
system_cpu_nice{cpu="cpu5"} 0 1631218450712
system_cpu_nice{cpu="cpu6"} 0 1631218450712
system_cpu_nice{cpu="cpu7"} 0 1631218450712
system_cpu_nice{cpu="cpu-total"} 0 1631218450712
# HELP system_cpu_iowait [GAUGE] Percent of time all cpus waiting for I/O to complete
# TYPE system_cpu_iowait GAUGE
system_cpu_iowait{cpu="cpu0"} 0.333333333325451 1631218450712
system_cpu_iowait{cpu="cpu1"} 0.3278688524611673 1631218450712
system_cpu_iowait{cpu="cpu2"} 1.3377926420392448 1631218450712
system_cpu_iowait{cpu="cpu3"} 0.33557046980808 1631218450712
system_cpu_iowait{cpu="cpu4"} 0.3300330033044907 1631218450712
system_cpu_iowait{cpu="cpu5"} 0.33444816050220677 1631218450712
system_cpu_iowait{cpu="cpu6"} 0.3322259136017879 1631218450712
system_cpu_iowait{cpu="cpu7"} 0 1631218450712
system_cpu_iowait{cpu="cpu-total"} 0.45719035743224296 1631218450712
# HELP system_cpu_irq [GAUGE] Percent of time all cpus servicing interrupts
# TYPE system_cpu_irq GAUGE
system_cpu_irq{cpu="cpu0"} 0 1631218450712
system_cpu_irq{cpu="cpu1"} 0 1631218450712
system_cpu_irq{cpu="cpu2"} 0 1631218450712
system_cpu_irq{cpu="cpu3"} 0 1631218450712
system_cpu_irq{cpu="cpu4"} 0 1631218450712
system_cpu_irq{cpu="cpu5"} 0 1631218450712
system_cpu_irq{cpu="cpu6"} 0 1631218450712
system_cpu_irq{cpu="cpu7"} 0 1631218450712
system_cpu_irq{cpu="cpu-total"} 0 1631218450712
# HELP system_cpu_sortirq [GAUGE] Percent of time all cpus servicing software interrupts
# TYPE system_cpu_sortirq GAUGE
system_cpu_sortirq{cpu="cpu0"} 0.9999999999611949 1631218450712
system_cpu_sortirq{cpu="cpu1"} 2.295081967168532 1631218450712
system_cpu_sortirq{cpu="cpu2"} 0 1631218450712
system_cpu_sortirq{cpu="cpu3"} 0 1631218450712
system_cpu_sortirq{cpu="cpu4"} 0.3300330033044907 1631218450712
system_cpu_sortirq{cpu="cpu5"} 0 1631218450712
system_cpu_sortirq{cpu="cpu6"} 0 1631218450712
system_cpu_sortirq{cpu="cpu7"} 0 1631218450712
system_cpu_sortirq{cpu="cpu-total"} 0.4156275976574278 1631218450712
# HELP system_cpu_stolen [GAUGE] Percent of time all cpus serviced virtual hosts operating systems
# TYPE system_cpu_stolen GAUGE
system_cpu_stolen{cpu="cpu0"} 0 1631218450712
system_cpu_stolen{cpu="cpu1"} 0 1631218450712
system_cpu_stolen{cpu="cpu2"} 0 1631218450712
system_cpu_stolen{cpu="cpu3"} 0 1631218450712
system_cpu_stolen{cpu="cpu4"} 0 1631218450712
system_cpu_stolen{cpu="cpu5"} 0 1631218450712
system_cpu_stolen{cpu="cpu6"} 0 1631218450712
system_cpu_stolen{cpu="cpu7"} 0 1631218450712
system_cpu_stolen{cpu="cpu-total"} 0 1631218450712
# HELP system_cpu_guest [GAUGE] Percent of time all cpus serviced guest operating system
# TYPE system_cpu_guest GAUGE
system_cpu_guest{cpu="cpu0"} 0 1631218450712
system_cpu_guest{cpu="cpu1"} 0 1631218450712
system_cpu_guest{cpu="cpu2"} 0 1631218450712
system_cpu_guest{cpu="cpu3"} 0 1631218450712
system_cpu_guest{cpu="cpu4"} 0 1631218450712
system_cpu_guest{cpu="cpu5"} 0 1631218450712
system_cpu_guest{cpu="cpu6"} 0 1631218450712
system_cpu_guest{cpu="cpu7"} 0 1631218450712
system_cpu_guest{cpu="cpu-total"} 0 1631218450712
# HELP system_cpu_guest_nice [GAUGE] Percent of time all cpus serviced niced guest operating system
# TYPE system_cpu_guest_nice GAUGE
system_cpu_guest_nice{cpu="cpu0"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu1"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu2"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu3"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu4"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu5"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu6"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu7"} 0 1631218450712
system_cpu_guest_nice{cpu="cpu-total"} 0 1631218450712
# HELP system_mem_used [GAUGE] Percent of memory used
# TYPE system_mem_used GAUGE
system_mem_used{} 4.016378412331798 1631218450712
# HELP system_mem_used_bytes [GAUGE] Used memory in bytes
# TYPE system_mem_used_bytes GAUGE
system_mem_used_bytes{} 1.349320704e+09 1631218450712
# HELP system_mem_total_bytes [GAUGE] Total memory in bytes
# TYPE system_mem_total_bytes GAUGE
system_mem_total_bytes{} 3.3595457536e+10 1631218450712
# HELP system_swap_used [GAUGE] Percent of swap used
# TYPE system_swap_used GAUGE
system_swap_used{} 0 1631218450712
# HELP system_swap_used_bytes [GAUGE] Used swap in bytes
# TYPE system_swap_used_bytes GAUGE
system_swap_used_bytes{} 1.349320704e+09 1631218450712
# HELP system_swap_total_bytes [GAUGE] Total swap in bytes
# TYPE system_swap_total_bytes GAUGE
system_swap_total_bytes{} 3.4222370816e+10 1631218450712
# HELP system_load_load1 [GAUGE] System load averaged over 1 minute, high load value dependant on number of cpus in system
# TYPE system_load_load1 GAUGE
system_load_load1{} 0.85 1631218450712
# HELP system_load_load5 [GAUGE] System load averaged over 5 minute, high load value dependent on number of cpus in system
# TYPE system_load_load5 GAUGE
system_load_load5{} 0.72 1631218450712
# HELP system_load_load15 [GAUGE] System load averaged over 15 minute, high load value dependent on number of cpus in system
# TYPE system_load_load15 GAUGE
system_load_load15{} 0.64 1631218450712
# HELP system_load_load1_per_cpu [GAUGE] System load averaged over 1 minute normalized by cpu count, values > 1 means system may be overloaded
# TYPE system_load_load1_per_cpu GAUGE
system_load_load1_per_cpu{} 0.10625 1631218450712
# HELP system_load_load5_per_cpu [GAUGE] System load averaged over 5 minute normalized by cpu count, values > 1 means system may be overloaded
# TYPE system_load_load5_per_cpu GAUGE
system_load_load5_per_cpu{} 0.09 1631218450712
# HELP system_load_load15_per_cpu [GAUGE] System load averaged over 15 minute normalized by cpu count, values > 1 means system may be overloaded
# TYPE system_load_load15_per_cpu GAUGE
system_load_load15_per_cpu{} 0.08 1631218450712
# HELP system_host_uptime [COUNTER] Host uptime in seconds
# TYPE system_host_uptime COUNTER
system_host_uptime{} 2.068058e+06 1631218450712
# HELP system_host_processes [GAUGE] Number of host processes
# TYPE system_host_processes GAUGE
system_host_processes{} 249 1631218450712

```