### PR TITLE
minor improvements to testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Go Test
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   test:
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest, macos-11, windows-2022, ubuntu-18.04]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/main_test.go
+++ b/main_test.go
@@ -29,6 +29,8 @@ func TestCollectMetrics(t *testing.T) {
 		output = output + "\n"
 		output = output + fmt.Sprintf("%s\n", metrics[i].Output())
 	}
+
+	// Check that output contains the expected metrics/tags
 	assert.Contains(output, "system_cpu_cores{}")
 	assert.Contains(output, `system_cpu_idle{cpu="cpu-total"}`)
 	assert.Contains(output, `system_cpu_idle{cpu="cpu0"}`)
@@ -67,9 +69,16 @@ func TestCollectMetrics(t *testing.T) {
 	assert.Contains(output, "system_host_uptime{}")
 	assert.Contains(output, "system_host_processes{}")
 
+	// Check that metrics are parsable
 	var parser expfmt.TextParser
-	_, err = parser.TextToMetricFamilies(strings.NewReader(output))
+	parsedMetrics, err := parser.TextToMetricFamilies(strings.NewReader(output))
 	assert.NoError(err)
+
+	// Check that every metric has a HELP and TYPE line
+	for i := range parsedMetrics {
+		assert.NotNil(parsedMetrics[i].Help)
+		assert.NotNil(parsedMetrics[i].Type)
+	}
 	fmt.Println(output)
 
 }


### PR DESCRIPTION
This PR includes a small collection of improvements for automated testing:
- **Additional platforms for GitHub Test action**: previously only running on `latest` version of OSes, which actually aren't the latest...
- **On-demand GitHub action support**: Previously GitHub test action only ran on push, by adding `workflow_dispatch` it will enable on-demand execution of tests
- **Checks for HELP/TYPE in output**: Added a check to ensure that every metric has a `HELP` and `TYPE` line in the output. This will help prevent accidental additions of new metrics that don't have those lines.